### PR TITLE
Build cbf with PY_SSIZE_T_CLEAN to ensure compatibility with python>=3.10

### DIFF
--- a/src/python-cbf.c
+++ b/src/python-cbf.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -7,10 +8,10 @@
 
 static PyObject *py_cbf_compress(PyObject *self, PyObject *args) {
   const unsigned char *source;
-  int source_size;
+  Py_ssize_t source_size;
   unsigned char *dest;
-  int dest_size;
-  int compressed_size;
+  Py_ssize_t dest_size;
+  Py_ssize_t compressed_size;
 
   if (!PyArg_ParseTuple(args, "s#s#", &source, &source_size, &dest, &dest_size)) {
       return NULL;
@@ -24,9 +25,9 @@ static PyObject *py_cbf_compress(PyObject *self, PyObject *args) {
 
 static PyObject *py_cbf_uncompress(PyObject *self, PyObject *args) {
     const unsigned char *source;
-    int source_size;
+    Py_ssize_t source_size;
     unsigned char *dest;
-    int dest_size;
+    Py_ssize_t dest_size;
 
 
     if (!PyArg_ParseTuple(args, "s#s#", &source, &source_size, &dest, &dest_size)) {


### PR DESCRIPTION
Due to a change in Python 3.10 and up, `PY_SSIZE_T_CLEAN` has to be defined before including `Python.h`.
The effected formats have type Py_ssize_t. See Issue #16 as well as the [official documentation](https://docs.python.org/3/c-api/arg.html#strings-and-buffers) on this.

I tried this fix on my own machine with Python 3.11.0 and Fedora 37, and it seems to solve all issues related to Python 3.10 and up. 